### PR TITLE
feat: add inventory service with basic UI

### DIFF
--- a/Assets/Scripts/Client.meta
+++ b/Assets/Scripts/Client.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d3ec03636d00441cbd94b082f030cb5e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Client/InventoryTestUI.cs
+++ b/Assets/Scripts/Client/InventoryTestUI.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+public class InventoryTestUI : MonoBehaviour
+{
+    int charId;
+
+    void Start()
+    {
+        Database.Init();
+        charId = CharacterService.EnsureCharacter(1);
+    }
+
+    void OnGUI()
+    {
+        GUILayout.BeginVertical("box");
+        GUILayout.Label("Inventory Test");
+
+        List<InventoryService.ItemEntry> items = InventoryService.ListItems(charId);
+        foreach (var item in items)
+        {
+            GUILayout.BeginHorizontal();
+            GUILayout.Label($"{item.Name}: {item.Quantity}");
+            if (GUILayout.Button("+")) InventoryService.AddItem(charId, item.ItemId, 1);
+            if (GUILayout.Button("-")) InventoryService.RemoveItem(charId, item.ItemId, 1);
+            GUILayout.EndHorizontal();
+        }
+
+        GUILayout.EndVertical();
+    }
+}

--- a/Assets/Scripts/Client/InventoryTestUI.cs.meta
+++ b/Assets/Scripts/Client/InventoryTestUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e34e8188d7a42ff9eab46c5567d52d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Server/DB/Database.cs
+++ b/Assets/Scripts/Server/DB/Database.cs
@@ -17,6 +17,8 @@ public static class Database
                 _conn = new SQLiteConnection(dbPath, SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create);
                 _conn.CreateTable<Account>();
                 _conn.CreateTable<Character>();
+                _conn.CreateTable<Item>();
+                _conn.CreateTable<Inventory>();
             }
             return _conn;
         }
@@ -26,6 +28,7 @@ public static class Database
     {
         // força inicialização e criação das tabelas
         var _ = Conn;
+        InventoryService.Seed();
         Debug.Log($"[DB] Path: {dbPath}");
     }
 }
@@ -50,4 +53,20 @@ public class Character
     public float Y { get; set; }
     public float Z { get; set; }
     public string LastLogin { get; set; }
+}
+
+[Table("items")]
+public class Item
+{
+    [PrimaryKey, AutoIncrement] public int Id { get; set; }
+    [Unique] public string Name { get; set; }
+}
+
+[Table("inventory")]
+public class Inventory
+{
+    [PrimaryKey, AutoIncrement] public int Id { get; set; }
+    public int CharacterId { get; set; }
+    public int ItemId { get; set; }
+    public int Quantity { get; set; }
 }

--- a/Assets/Scripts/Server/DB/InventoryService.cs
+++ b/Assets/Scripts/Server/DB/InventoryService.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+public static class InventoryService
+{
+    public class ItemEntry
+    {
+        public int ItemId { get; set; }
+        public string Name { get; set; }
+        public int Quantity { get; set; }
+    }
+
+    public static void Seed()
+    {
+        // cria itens básicos se a tabela estiver vazia
+        if (Database.Conn.Table<Item>().Count() != 0) return;
+        Debug.unityLogger?.Log(LogType.Log, "[Inventory] seeding items");
+        Database.Conn.Insert(new Item { Name = "Potion" });
+        Database.Conn.Insert(new Item { Name = "Sword" });
+    }
+
+    public static void AddItem(int charId, int itemId, int qty)
+    {
+        if (qty <= 0) throw new ArgumentOutOfRangeException(nameof(qty));
+        var inv = Database.Conn.Table<Inventory>()
+            .FirstOrDefault(i => i.CharacterId == charId && i.ItemId == itemId);
+        if (inv == null)
+        {
+            inv = new Inventory { CharacterId = charId, ItemId = itemId, Quantity = qty };
+            Database.Conn.Insert(inv);
+        }
+        else
+        {
+            inv.Quantity += qty;
+            Database.Conn.Update(inv);
+        }
+    }
+
+    public static void RemoveItem(int charId, int itemId, int qty)
+    {
+        if (qty <= 0) throw new ArgumentOutOfRangeException(nameof(qty));
+        var inv = Database.Conn.Table<Inventory>()
+            .FirstOrDefault(i => i.CharacterId == charId && i.ItemId == itemId);
+        if (inv == null) return;
+        inv.Quantity -= qty;
+        if (inv.Quantity <= 0)
+            Database.Conn.Delete(inv);
+        else
+            Database.Conn.Update(inv);
+    }
+
+    public static List<ItemEntry> ListItems(int charId)
+    {
+        var items = Database.Conn.Table<Item>().ToList();
+        var result = new List<ItemEntry>();
+        foreach (var item in items)
+        {
+            var inv = Database.Conn.Table<Inventory>()
+                .FirstOrDefault(i => i.CharacterId == charId && i.ItemId == item.Id);
+            result.Add(new ItemEntry
+            {
+                ItemId = item.Id,
+                Name = item.Name,
+                Quantity = inv?.Quantity ?? 0
+            });
+        }
+        return result;
+    }
+}

--- a/Assets/Scripts/Server/DB/InventoryService.cs.meta
+++ b/Assets/Scripts/Server/DB/InventoryService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90d05c094e4d4cf39141750ca026c9bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add SQLite tables for items and inventory
- implement InventoryService for adding/removing/listing items
- simple InventoryTestUI for manual testing

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d1ba648488322a0ad77bea5776ef5