### PR TITLE
feat: add autosave and login feedback

### DIFF
--- a/Assets/Client/LoginUI.cs
+++ b/Assets/Client/LoginUI.cs
@@ -31,6 +31,16 @@ public class LoginUI : MonoBehaviour
         ShowStatus("Pronto.");
     }
 
+    void OnEnable()
+    {
+        SimpleAuthenticator.ClientAuthFailed += OnAuthFailed;
+    }
+
+    void OnDisable()
+    {
+        SimpleAuthenticator.ClientAuthFailed -= OnAuthFailed;
+    }
+
     // dentro de LoginUI.cs
     public void Connect()
     {
@@ -83,6 +93,18 @@ public class LoginUI : MonoBehaviour
     void OnClientDisconnected()
     {
         ShowStatus("Desconectado do servidor.");
+    }
+
+    void OnAuthFailed(string serverMessage)
+    {
+        ShowStatus(MapAuthMessage(serverMessage));
+    }
+
+    string MapAuthMessage(string msg)
+    {
+        if (string.IsNullOrWhiteSpace(msg)) return "Falha ao autenticar.";
+        if (msg.Contains("Credenciais inválidas")) return "Credenciais inválidas.";
+        return msg;
     }
 
     // -------- UI helpers --------

--- a/Assets/Scripts/Server/AutoSaveSystem.cs
+++ b/Assets/Scripts/Server/AutoSaveSystem.cs
@@ -1,0 +1,35 @@
+using Mirror;
+using UnityEngine;
+
+/// <summary>
+/// Periodically saves all connected players' positions.
+/// </summary>
+public class AutoSaveSystem : MonoBehaviour
+{
+    [SerializeField] float intervalSeconds = 30f;
+
+    void Start()
+    {
+        if (intervalSeconds <= 0f) intervalSeconds = 30f;
+        InvokeRepeating(nameof(SaveAllPlayers), intervalSeconds, intervalSeconds);
+    }
+
+    void OnDestroy()
+    {
+        CancelInvoke();
+    }
+
+    [Server]
+    void SaveAllPlayers()
+    {
+        if (!NetworkServer.active) return;
+
+        foreach (var kvp in NetworkServer.connections)
+        {
+            var conn = kvp.Value;
+            if (conn?.identity == null) continue;
+            var net = conn.identity.GetComponent<PlayerNetwork>();
+            net?.ServerSaveNow();
+        }
+    }
+}

--- a/Assets/Scripts/Server/AutoSaveSystem.cs.meta
+++ b/Assets/Scripts/Server/AutoSaveSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c16f84ccc9b4a77b714f1161efa9ab8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Server/ServerBootstrap.cs
+++ b/Assets/Scripts/Server/ServerBootstrap.cs
@@ -2,5 +2,9 @@ using UnityEngine;
 
 public class ServerBootstrap : MonoBehaviour
 {
-    void Awake() => Database.Init();
+    void Awake()
+    {
+        Database.Init();
+        gameObject.AddComponent<AutoSaveSystem>();
+    }
 }

--- a/Assets/Scripts/Server/SimpleAuthenticator.cs
+++ b/Assets/Scripts/Server/SimpleAuthenticator.cs
@@ -1,5 +1,6 @@
 using Mirror;
 using UnityEngine;
+using System;
 
 public class SimpleAuthenticator : NetworkAuthenticator
 {
@@ -20,6 +21,8 @@ public class SimpleAuthenticator : NetworkAuthenticator
         public bool success;
         public string message;
     }
+
+    public static event Action<string> ClientAuthFailed;
 
     // ===== SERVER =====
     public override void OnStartServer()
@@ -92,6 +95,7 @@ public class SimpleAuthenticator : NetworkAuthenticator
         else
         {
             Debug.LogWarning("[Auth] Falha de autenticação no cliente: " + msg.message);
+            ClientAuthFailed?.Invoke(msg.message);
             NetworkClient.Disconnect();
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # LanOfGuardians
+
+Protótipo em Unity 2021.3 usando Mirror para rede e SQLite para persistência.
+
+## Troubleshooting de Login
+- **Servidor inatingível**: verifique IP/porta e se o servidor está em execução.
+- **"Credenciais inválidas"**: confirme usuário e senha. Use a opção "criar conta" se necessário.
+- **Authenticator não atribuído**: arraste `SimpleAuthenticator` para o `NetworkManager`.
+- **Desconexão imediata**: confira se o banco de dados pode ser acessado (arquivo bloqueado ou ausente).


### PR DESCRIPTION
## Summary
- save all connected players automatically every 30 seconds
- show clearer login errors from server responses
- document common login issues

## Testing
- `dotnet --version` *(fail: command not found)*
- `mcs --version` *(fail: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d1b85a3c88322a4d375ced53a86c3