### PR TITLE
feat: server-authoritative 2D player movement and camera follow

### DIFF
--- a/Assets/Scripts/Client.meta
+++ b/Assets/Scripts/Client.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 05fd8758e2cb423383abe77c652c37e6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Client/CameraFollow2D.cs
+++ b/Assets/Scripts/Client/CameraFollow2D.cs
@@ -1,0 +1,20 @@
+using Mirror;
+using UnityEngine;
+
+public class CameraFollow2D : MonoBehaviour
+{
+    Transform target;
+
+    void LateUpdate()
+    {
+        if (target == null)
+        {
+            if (NetworkClient.localPlayer == null) return;
+            target = NetworkClient.localPlayer.transform;
+        }
+
+        Vector3 position = target.position;
+        position.z = transform.position.z;
+        transform.position = position;
+    }
+}

--- a/Assets/Scripts/Client/CameraFollow2D.cs.meta
+++ b/Assets/Scripts/Client/CameraFollow2D.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b52fd04c986462199da7d749e054460
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Shared/PlayerMovement2D.cs
+++ b/Assets/Scripts/Shared/PlayerMovement2D.cs
@@ -1,0 +1,50 @@
+using Mirror;
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody2D))]
+public class PlayerMovement2D : NetworkBehaviour
+{
+    [SerializeField] float speed = 5f;
+
+    Rigidbody2D rb;
+    Vector2 moveDirection;
+
+    void Awake()
+    {
+        rb = GetComponent<Rigidbody2D>();
+        rb.gravityScale = 0f;
+    }
+
+    void Update()
+    {
+        if (!isLocalPlayer) return;
+
+        Vector2 input = new Vector2(Input.GetAxisRaw("Horizontal"), Input.GetAxisRaw("Vertical"));
+        if (input.sqrMagnitude > 0f)
+        {
+            CmdMove(input.normalized);
+        }
+        else
+        {
+            CmdStop();
+        }
+    }
+
+    [Command]
+    void CmdMove(Vector2 direction)
+    {
+        moveDirection = direction;
+    }
+
+    [Command]
+    void CmdStop()
+    {
+        moveDirection = Vector2.zero;
+    }
+
+    void FixedUpdate()
+    {
+        if (!isServer) return;
+        rb.velocity = moveDirection * speed;
+    }
+}

--- a/Assets/Scripts/Shared/PlayerMovement2D.cs.meta
+++ b/Assets/Scripts/Shared/PlayerMovement2D.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97f69876956546fd88fa810c7db3e626
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # LanOfGuardians
+
+## Teste manual (2 clientes)
+
+1. Adicione **PlayerMovement2D** ao objeto do jogador contendo `Rigidbody2D` (gravity scale = 0) e mantenha `NetworkTransformHybrid` no objeto raiz.
+2. Anexe **CameraFollow2D** à câmera principal.
+3. Abra duas instâncias do jogo (ex.: Editor como Host e Build como Client).
+4. No Host, inicie como servidor/jogador; no segundo cliente, conecte em `localhost`.
+5. Use **WASD** para mover o jogador e verifique que o movimento é aplicado pelo servidor e sincronizado entre as instâncias.


### PR DESCRIPTION
## Summary
- add PlayerMovement2D with server-authoritative Rigidbody2D movement
- add CameraFollow2D to track local player
- document two-client test steps

## Testing
- `dotnet build` *(fails: command not found)*
- `mcs Assets/Scripts/Shared/PlayerMovement2D.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d1aecb58083229e4778fcdeca25f7