### PR TITLE
feat: server autosave and clearer login errors

### DIFF
--- a/Assets/Client/LoginUI.cs
+++ b/Assets/Client/LoginUI.cs
@@ -31,6 +31,9 @@ public class LoginUI : MonoBehaviour
         ShowStatus("Pronto.");
     }
 
+    void OnEnable() => SimpleAuthenticator.AuthResponseReceived += OnAuthResponse;
+    void OnDisable() => SimpleAuthenticator.AuthResponseReceived -= OnAuthResponse;
+
     // dentro de LoginUI.cs
     public void Connect()
     {
@@ -104,4 +107,14 @@ public class LoginUI : MonoBehaviour
         // também manda pro console
         Debug.Log($"[LoginUI] {msg}");
     }
+
+    void OnAuthResponse(SimpleAuthenticator.AuthResponse msg) =>
+        ShowStatus(MapAuthMessage(msg.message));
+
+    static string MapAuthMessage(string serverMessage) => serverMessage switch
+    {
+        "Credenciais inválidas." => "Credenciais inválidas",
+        "OK" => "Login realizado com sucesso.",
+        _ => serverMessage
+    };
 }

--- a/Assets/Scripts/Server/AutoSaveSystem.cs
+++ b/Assets/Scripts/Server/AutoSaveSystem.cs
@@ -1,0 +1,21 @@
+using Mirror;
+using UnityEngine;
+
+public class AutoSaveSystem : MonoBehaviour
+{
+    const float SaveInterval = 30f;
+
+    [ServerCallback]
+    void Start() => InvokeRepeating(nameof(SaveAllPlayers), SaveInterval, SaveInterval);
+
+    [Server]
+    void SaveAllPlayers()
+    {
+        foreach (var conn in NetworkServer.connections.Values)
+        {
+            var player = conn.identity != null ? conn.identity.GetComponent<PlayerNetwork>() : null;
+            if (player != null)
+                player.ServerSaveNow();
+        }
+    }
+}

--- a/Assets/Scripts/Server/ServerBootstrap.cs
+++ b/Assets/Scripts/Server/ServerBootstrap.cs
@@ -2,5 +2,9 @@ using UnityEngine;
 
 public class ServerBootstrap : MonoBehaviour
 {
-    void Awake() => Database.Init();
+    void Awake()
+    {
+        Database.Init();
+        gameObject.AddComponent<AutoSaveSystem>();
+    }
 }

--- a/Assets/Scripts/Server/SimpleAuthenticator.cs
+++ b/Assets/Scripts/Server/SimpleAuthenticator.cs
@@ -1,3 +1,4 @@
+using System;
 using Mirror;
 using UnityEngine;
 
@@ -20,6 +21,8 @@ public class SimpleAuthenticator : NetworkAuthenticator
         public bool success;
         public string message;
     }
+
+    public static event Action<AuthResponse> AuthResponseReceived;
 
     // ===== SERVER =====
     public override void OnStartServer()
@@ -84,6 +87,8 @@ public class SimpleAuthenticator : NetworkAuthenticator
 
     void OnAuthResponse(AuthResponse msg)
     {
+        AuthResponseReceived?.Invoke(msg);
+
         if (msg.success)
         {
             Debug.Log("[Auth] Cliente autenticado (recebeu OK)");

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # LanOfGuardians
+
+## Troubleshooting de Login
+
+- **Credenciais inválidas**: confirme usuário e senha; respeite maiúsculas/minúsculas.
+- **Sem resposta do servidor**: verifique o endereço/IP e se o servidor está em execução.
+- **Desconectado imediatamente**: cheque os logs do servidor para mensagens detalhadas.


### PR DESCRIPTION
## Summary
- save all connected players every 30s on server
- surface authentication messages in Login UI
- document login troubleshooting

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d1b5d7d4c832288962cd6519bcc93